### PR TITLE
Tonkeeper WebView UserAgent

### DIFF
--- a/LocalPackages/TKScreenKit/TKScreenKit/Sources/TKScreenKit/TKBridgeWebViewController/TKBridgeWebViewController.swift
+++ b/LocalPackages/TKScreenKit/TKScreenKit/Sources/TKScreenKit/TKBridgeWebViewController/TKBridgeWebViewController.swift
@@ -32,6 +32,12 @@ open class TKBridgeWebViewController: UIViewController {
     userContentController.addUserScript(script)
     configuration.userContentController = userContentController
     let webView = WKWebView(frame: .zero, configuration: configuration)
+    // Set custom user agent
+    if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+       let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String {
+        let userAgent = "Tonkeeper iOS/\(appVersion) (Build \(buildNumber))"
+        webView.customUserAgent = userAgent
+    }
     return webView
   }()
   

--- a/LocalPackages/TKScreenKit/TKScreenKit/Sources/TKScreenKit/TKWebViewController/TKWebViewController.swift
+++ b/LocalPackages/TKScreenKit/TKScreenKit/Sources/TKScreenKit/TKWebViewController/TKWebViewController.swift
@@ -22,6 +22,12 @@ public final class TKWebViewController: UIViewController {
     view.backgroundColor = .Background.page
     webView.backgroundColor = .Background.page
     webView.scrollView.backgroundColor = .Background.page
+    // Set custom user agent
+    if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+       let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String {
+        let userAgent = "Tonkeeper iOS/\(appVersion) (Build \(buildNumber))"
+        webView.customUserAgent = userAgent
+    }
     webView.load(URLRequest(url: url))
     setupRightCloseButton { [weak self] in
       self?.dismiss(animated: true)

--- a/LocalPackages/TKUIKit/TKUIKit/Sources/TKScreenKit/TKWebViewController/TKWebViewController.swift
+++ b/LocalPackages/TKUIKit/TKUIKit/Sources/TKScreenKit/TKWebViewController/TKWebViewController.swift
@@ -22,6 +22,12 @@ public final class TKWebViewController: UIViewController {
     view.backgroundColor = .Background.page
     webView.backgroundColor = .Background.page
     webView.scrollView.backgroundColor = .Background.page
+    // Set custom user agent
+    if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+      let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String {
+      let userAgent = "Tonkeeper iOS/\(appVersion) (Build \(buildNumber))"
+      webView.customUserAgent = userAgent
+    }
     webView.load(URLRequest(url: url))
     setupRightCloseButton { [weak self] in
       self?.dismiss(animated: true)


### PR DESCRIPTION
In the previous app version, `?utm_source=tonkeeper` was automatically added to all visited websites.

We suggest keeping this approach, or alternatively, implementing a custom `User-Agent` to identify the Tonkeeper Browser and create a better experience for all app users with dApps.