### PR TITLE
TON DNS case-sensitive

### DIFF
--- a/LocalPackages/core-swift/Sources/KeeperCore/Services/DNSService/DNSService.swift
+++ b/LocalPackages/core-swift/Sources/KeeperCore/Services/DNSService/DNSService.swift
@@ -25,11 +25,12 @@ final class DNSServiceImplementation: DNSService {
   }
   
   func resolveDomainName(_ domainName: String, addTonPostfix: Bool, isTestnet: Bool) async throws -> Domain {
+    let normalizedDomainName = domainName.lowercased()
     let resolveName: String = {
       if addTonPostfix {
-        return parseDomainName(domainName)
+        return parseDomainName(normalizedDomainName)
       } else {
-        return domainName
+        return normalizedDomainName
       }
     }()
     


### PR DESCRIPTION
Domain names should be normalized to lower-case before DNS resolution.